### PR TITLE
Added a llink to the forum thread

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -16,7 +16,7 @@
 		<language>de</language>
 		<platform>all</platform>
 		<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
-		<forum></forum>
+		<forum>http://forum.kodi.tv/showthread.php?tid=225198</forum>
 		<website>http://www.dzango.de</website>
 		<email>bromix at gmx dot net</email>
 		<source>https://github.com/bromix/plugin.video.dzango.tv</source>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.